### PR TITLE
Fix category generator

### DIFF
--- a/scripts/lib/generators/category.js
+++ b/scripts/lib/generators/category.js
@@ -11,7 +11,7 @@ class CategoryGenerator {
   configs = {}
 
   constructor(categories, posts, configs) {
-    this.data = categories
+    this.data = this.data.concat(categories)
     this.posts = posts
     this.configs = configs
     this.reduceCategories()


### PR DESCRIPTION
- A "TypeError: this.data is not iterable" error occurs when there is no category.


```
FATAL Something's wrong. Maybe you can find the solution here: https://hexo.io/docs/troubleshooting.html
TypeError: this.data is not iterable
    at new CategoryGenerator (/usr/src/blog/themes/hexo-theme-aurora/scripts/lib/generators/category.js:18:25)
    at generator (/usr/src/blog/themes/hexo-theme-aurora/scripts/lib/generators/index.js:99:24)
    at Hexo.<anonymous> (/usr/src/blog/themes/hexo-theme-aurora/scripts/lib/generators/index.js:79:12)
    at Hexo.tryCatcher (/usr/src/blog/node_modules/bluebird/js/release/util.js:16:23)
    at Hexo.<anonymous> (/usr/src/blog/node_modules/bluebird/js/release/method.js:15:34)
    at /usr/src/blog/node_modules/hexo/lib/hexo/index.js:407:22
    at tryCatcher (/usr/src/blog/node_modules/bluebird/js/release/util.js:16:23)
    at MappingPromiseArray._promiseFulfilled (/usr/src/blog/node_modules/bluebird/js/release/map.js:68:38)
    at PromiseArray._iterate (/usr/src/blog/node_modules/bluebird/js/release/promise_array.js:115:31)
    at MappingPromiseArray.init (/usr/src/blog/node_modules/bluebird/js/release/promise_array.js:79:10)
    at MappingPromiseArray._asyncInit (/usr/src/blog/node_modules/bluebird/js/release/map.js:37:10)
    at _drainQueueStep (/usr/src/blog/node_modules/bluebird/js/release/async.js:97:12)
    at _drainQueue (/usr/src/blog/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/usr/src/blog/node_modules/bluebird/js/release/async.js:102:5)
    at Async.drainQueues [as _onImmediate] (/usr/src/blog/node_modules/bluebird/js/release/async.js:15:14)
    at process.processImmediate (node:internal/timers:478:21)
```
